### PR TITLE
ConcludePowderTest - new token format

### DIFF
--- a/docker/docker-compose-am-lab.yml
+++ b/docker/docker-compose-am-lab.yml
@@ -29,7 +29,7 @@ services:
     networks: ['am']
 
   ipfs-eve:
-    image: ghcr.io/digicatapult/vitalam-ipfs:v1.0.0
+    image: ghcr.io/digicatapult/vitalam-ipfs:v1.1.0
     container_name: ipfs-eve
     ports:
       - 5004:5001
@@ -42,7 +42,7 @@ services:
     networks: ['am']
 
   api-eve:
-    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.2
     container_name: api-eve
     ports:
       - 3004:3001

--- a/docker/docker-compose-am-lab.yml
+++ b/docker/docker-compose-am-lab.yml
@@ -8,10 +8,9 @@ networks:
 services:
 
   node-eve:
-    image: ghcr.io/digicatapult/vitalam-node:v2.5.1
+    image: ghcr.io/digicatapult/vitalam-node:v2.7.0
     container_name: node-eve
-    command: /bin/sh -c "
-      ./vitalam-node
+    command:
       --base-path /data/
       --eve
       --node-key ${NODE_EVE_KEY}
@@ -19,7 +18,7 @@ services:
       --chain local
       --unsafe-ws-external
       --unsafe-rpc-external
-      --rpc-cors all"
+      --rpc-cors all
     ports:
       - 30336:30333
       - 9947:9944
@@ -43,7 +42,7 @@ services:
     networks: ['am']
 
   api-eve:
-    image: ghcr.io/digicatapult/vitalam-api:v2.4.1
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
     container_name: api-eve
     ports:
       - 3004:3001

--- a/docker/docker-compose-am.yml
+++ b/docker/docker-compose-am.yml
@@ -13,10 +13,9 @@ networks:
 
 services:
   node-bob:
-    image: ghcr.io/digicatapult/vitalam-node:v2.5.1
+    image: ghcr.io/digicatapult/vitalam-node:v2.7.0
     container_name: node-bob
-    command: /bin/sh -c "
-      ./vitalam-node
+    command:
       --base-path /data/
       --bob
       --node-key ${NODE_BOB_KEY}
@@ -25,7 +24,7 @@ services:
       --chain local
       --unsafe-ws-external
       --unsafe-rpc-external
-      --rpc-cors all"
+      --rpc-cors all
     ports:
       - 30334:30333
       - 9945:9944
@@ -49,7 +48,7 @@ services:
     networks: ['ipfs', 'am']
 
   api-bob:
-    image: ghcr.io/digicatapult/vitalam-api:v2.4.1
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
     container_name: api-bob
     ports:
       - 3002:3001

--- a/docker/docker-compose-am.yml
+++ b/docker/docker-compose-am.yml
@@ -35,7 +35,7 @@ services:
     networks: ['chain', 'am']
 
   ipfs-bob:
-    image: ghcr.io/digicatapult/vitalam-ipfs:v1.0.0
+    image: ghcr.io/digicatapult/vitalam-ipfs:v1.1.0
     container_name: ipfs-bob
     ports:
       - 5002:5001
@@ -48,7 +48,7 @@ services:
     networks: ['ipfs', 'am']
 
   api-bob:
-    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.2
     container_name: api-bob
     ports:
       - 3002:3001

--- a/docker/docker-compose-cust.yml
+++ b/docker/docker-compose-cust.yml
@@ -35,7 +35,7 @@ services:
     networks: ['chain', 'cust']
 
   ipfs-alice:
-    image: ghcr.io/digicatapult/vitalam-ipfs:v1.0.0
+    image: ghcr.io/digicatapult/vitalam-ipfs:v1.1.0
     container_name: ipfs-alice
     ports:
       - 5001:5001
@@ -48,7 +48,7 @@ services:
     networks: ['ipfs', 'cust']
 
   api-alice:
-    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.2
     container_name: api-alice
     ports:
       - 3001:3001

--- a/docker/docker-compose-cust.yml
+++ b/docker/docker-compose-cust.yml
@@ -13,10 +13,9 @@ networks:
 
 services:
   node-alice:
-    image: ghcr.io/digicatapult/vitalam-node:v2.5.1
+    image: ghcr.io/digicatapult/vitalam-node:v2.7.0
     container_name: node-alice
-    command: /bin/sh -c "
-      ./vitalam-node
+    command:
       --base-path /data/
       --alice
       --node-key ${NODE_ALICE_KEY}
@@ -25,7 +24,7 @@ services:
       --chain local
       --unsafe-ws-external
       --unsafe-rpc-external
-      --rpc-cors all"
+      --rpc-cors all
     ports:
       - 30333:30333
       - 9944:9944
@@ -49,7 +48,7 @@ services:
     networks: ['ipfs', 'cust']
 
   api-alice:
-    image: ghcr.io/digicatapult/vitalam-api:v2.4.1
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
     container_name: api-alice
     ports:
       - 3001:3001

--- a/docker/docker-compose-lab.yml
+++ b/docker/docker-compose-lab.yml
@@ -13,10 +13,9 @@ networks:
 
 services:
   node-charlie:
-    image: ghcr.io/digicatapult/vitalam-node:v2.5.1
+    image: ghcr.io/digicatapult/vitalam-node:v2.7.0
     container_name: node-charlie
-    command: /bin/sh -c "
-      ./vitalam-node
+    command:
       --base-path /data/
       --charlie
       --node-key ${NODE_CHARLIE_KEY}
@@ -25,7 +24,7 @@ services:
       --chain local
       --unsafe-ws-external
       --unsafe-rpc-external
-      --rpc-cors all"
+      --rpc-cors all
     ports:
       - 30335:30333
       - 9946:9944
@@ -49,7 +48,7 @@ services:
     networks: ['ipfs', 'lab']
 
   api-charlie:
-    image: ghcr.io/digicatapult/vitalam-api:v2.4.1
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
     container_name: api-charlie
     ports:
       - 3003:3001

--- a/docker/docker-compose-lab.yml
+++ b/docker/docker-compose-lab.yml
@@ -48,7 +48,7 @@ services:
     networks: ['ipfs', 'lab']
 
   api-charlie:
-    image: ghcr.io/digicatapult/vitalam-api:v2.6.0
+    image: vitalam-api-local
     container_name: api-charlie
     ports:
       - 3003:3001

--- a/docker/docker-compose-lab.yml
+++ b/docker/docker-compose-lab.yml
@@ -35,7 +35,7 @@ services:
     networks: ['chain', 'lab']
 
   ipfs-charlie:
-    image: ghcr.io/digicatapult/vitalam-ipfs:v1.0.0
+    image: ghcr.io/digicatapult/vitalam-ipfs:v1.1.0
     container_name: ipfs-charlie
     ports:
       - 5003:5001
@@ -48,7 +48,7 @@ services:
     networks: ['ipfs', 'lab']
 
   api-charlie:
-    image: vitalam-api-local
+    image: ghcr.io/digicatapult/vitalam-api:v2.6.2
     container_name: api-charlie
     ports:
       - 3003:3001

--- a/src/am/components/Attachment.js
+++ b/src/am/components/Attachment.js
@@ -43,36 +43,13 @@ const Attachment = ({ name, downloadData }) => {
   const [url, setURL] = useState('')
 
   useEffect(() => {
-    const dataURItoObjectURL = (dataURI) => {
-      if (!dataURI) {
-        return ''
-      } else {
-        const [dataURIHeader, dataBase64] = dataURI.split(',')
-
-        const byteString = atob(dataBase64)
-        const mimeString = dataURIHeader.split(':')[1].split(';')[0]
-
-        const ab = new ArrayBuffer(byteString.length)
-        const ia = new Uint8Array(ab)
-        for (let counter = 0; counter < byteString.length; counter++) {
-          ia[counter] = byteString.charCodeAt(counter)
-        }
-
-        const blob = new Blob([ab], { type: mimeString })
-        const url = URL.createObjectURL(blob)
-
-        return url
-      }
-    }
-
-    const url = dataURItoObjectURL(downloadData)
-    setURL(url)
+    setURL(downloadData)
 
     return () => {
       URL.revokeObjectURL(url)
       setURL('')
     }
-  }, [downloadData, setURL])
+  }, [downloadData, url])
 
   return (
     <Box className={classes.attachmentContainer}>

--- a/src/am/components/Navigation.js
+++ b/src/am/components/Navigation.js
@@ -5,6 +5,7 @@ import { Toolbar, Typography, Box } from '@material-ui/core'
 import { useSelector } from 'react-redux'
 
 import logo from '../../images/maher.png'
+import { tokenTypes, powderTestStatus } from '../../utils'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -62,7 +63,8 @@ const Navigation = () => {
   const powders = useSelector((state) => state.powders)
   const testResults = useSelector((state) =>
     state.labTests.filter(
-      ({ type, status }) => type === 'POWDER_TEST' && status === 'result'
+      ({ type, status }) =>
+        type === tokenTypes.powderTest && status === powderTestStatus.result
     )
   )
 

--- a/src/am/components/Navigation.js
+++ b/src/am/components/Navigation.js
@@ -63,7 +63,7 @@ const Navigation = () => {
   const powders = useSelector((state) => state.powders)
   const testResults = useSelector((state) =>
     state.labTests.filter(
-      ({ type, status }) =>
+      ({ metadata: { type, status } }) =>
         type === tokenTypes.powderTest && status === powderTestStatus.result
     )
   )

--- a/src/am/components/Navigation.js
+++ b/src/am/components/Navigation.js
@@ -61,7 +61,9 @@ const Navigation = () => {
   const customerOrders = useSelector((state) => state.customerOrders)
   const powders = useSelector((state) => state.powders)
   const testResults = useSelector((state) =>
-    state.labTests.filter(({ type }) => type === 'PowderTestResult')
+    state.labTests.filter(
+      ({ type, status }) => type === 'POWDER_TEST' && status === 'result'
+    )
   )
 
   const hasNewOrder = customerOrders.some(

--- a/src/am/components/Powders/Powders.js
+++ b/src/am/components/Powders/Powders.js
@@ -32,7 +32,8 @@ const Powders = () => {
       <Grid container direction="column">
         {[...powders].reverse().map((powder) => {
           const labTest =
-            labTests.find(({ powderId }) => powderId === powder.id) || null
+            labTests.find(({ metadata }) => metadata.powderId === powder.id) ||
+            null
           return <PowderRow key={powder.id} powder={powder} labTest={labTest} />
         })}
       </Grid>

--- a/src/am/components/Powders/PowdersDetail.js
+++ b/src/am/components/Powders/PowdersDetail.js
@@ -87,7 +87,8 @@ const PowdersDetail = () => {
   const classes = useStyles()
   const { powder, labTest } = useSelector((state) => ({
     powder: state.powders.find(({ id: powderId }) => id === powderId) || {},
-    labTest: state.labTests.find(({ powderId }) => id === powderId) || null,
+    labTest:
+      state.labTests.find(({ metadata }) => id === metadata.powderId) || null,
   }))
   const api = useApi()
 
@@ -165,8 +166,8 @@ const PowdersDetail = () => {
     const labTestToken = {
       id: response[0],
       original_id: response[0],
-      latestId: response[0],
-      ...outputData[0],
+      roles: { Owner: outputData[0].owner },
+      metadata: outputData[0],
     }
 
     dispatch(upsertLabTest(labTestToken))

--- a/src/am/components/Powders/PowdersDetail.js
+++ b/src/am/components/Powders/PowdersDetail.js
@@ -24,7 +24,7 @@ import Header from '../Header'
 import { markPowderRead } from '../../../features/readPowdersSlice'
 import { identities, useApi } from '../../../utils'
 import { upsertPowder } from '../../../features/powdersSlice'
-import { addLabTest } from '../../../features/labTestsSlice'
+import { upsertLabTest } from '../../../features/labTestsSlice'
 
 const useStyles = makeStyles({
   header: {
@@ -164,11 +164,12 @@ const PowdersDetail = () => {
     }
     const labTestToken = {
       id: response[0],
+      original_id: response[0],
       latestId: response[0],
       ...outputData[0],
     }
 
-    dispatch(addLabTest(labTestToken))
+    dispatch(upsertLabTest(labTestToken))
     dispatch(upsertPowder(powderToken))
 
     navigate('/app/powders')

--- a/src/am/components/Powders/Status.js
+++ b/src/am/components/Powders/Status.js
@@ -27,10 +27,10 @@ const PowderStatus = ({ labTest }) => {
   let powderStatus = null
   if (labTest === null) {
     powderStatus = 'testRequired'
-  } else if (!labTest.overallResult) {
+  } else if (!labTest.metadata.overallResult) {
     powderStatus = 'testRequested'
   } else {
-    powderStatus = labTest.overallResult
+    powderStatus = labTest.metadata.overallResult
   }
 
   let statusText = null,

--- a/src/am/components/Tests/Detail.js
+++ b/src/am/components/Tests/Detail.js
@@ -103,7 +103,7 @@ const OrderDetail = ({ test }) => {
           <Typography variant="body1" className={classes.fontBold}>
             Reason:
           </Typography>
-          {testReason?.url ? (
+          {testReason ? (
             <Attachment name={testReason.name} downloadData={testReason.url} />
           ) : (
             <Typography>No reason given</Typography>
@@ -134,7 +134,7 @@ const OrderDetail = ({ test }) => {
           </Box>
         ))}
         <Box className={classes.attachment}>
-          {testReport?.url ? (
+          {testReport ? (
             <>
               <DetailRow title="Attached Documents"></DetailRow>
               <Attachment

--- a/src/am/components/Tests/Detail.js
+++ b/src/am/components/Tests/Detail.js
@@ -103,7 +103,11 @@ const OrderDetail = ({ test }) => {
           <Typography variant="body1" className={classes.fontBold}>
             Reason:
           </Typography>
-          <Typography>{testReason}</Typography>
+          {testReason?.url ? (
+            <Attachment name={testReason.name} downloadData={testReason.url} />
+          ) : (
+            <Typography>No reason given</Typography>
+          )}
         </Grid>
       </Grid>
 
@@ -130,11 +134,17 @@ const OrderDetail = ({ test }) => {
           </Box>
         ))}
         <Box className={classes.attachment}>
-          <DetailRow title="Attached Documents"></DetailRow>
-          <Attachment
-            name="Powder test results.PDF"
-            downloadData={testReport}
-          />
+          {testReport?.url ? (
+            <>
+              <DetailRow title="Attached Documents"></DetailRow>
+              <Attachment
+                name={testReport.name}
+                downloadData={testReport.url}
+              />
+            </>
+          ) : (
+            <DetailRow title="Report" value="No report"></DetailRow>
+          )}
         </Box>
       </Box>
     </Paper>

--- a/src/am/components/Tests/Detail.js
+++ b/src/am/components/Tests/Detail.js
@@ -52,7 +52,9 @@ const DetailRow = ({ title, value }) => {
 }
 
 const OrderDetail = ({ test }) => {
-  const { overallResult, testReason, testReport, powderId } = test
+  const {
+    metadata: { overallResult, testReason, testReport, powderId },
+  } = test
 
   const classes = useStyles()
   const dispatch = useDispatch()
@@ -104,7 +106,10 @@ const OrderDetail = ({ test }) => {
             Reason:
           </Typography>
           {testReason ? (
-            <Attachment name={testReason.name} downloadData={testReason.url} />
+            <Attachment
+              name={testReason.fileName}
+              downloadData={testReason.url}
+            />
           ) : (
             <Typography>No reason given</Typography>
           )}
@@ -138,7 +143,7 @@ const OrderDetail = ({ test }) => {
             <>
               <DetailRow title="Attached Documents"></DetailRow>
               <Attachment
-                name={testReport.name}
+                name={testReport.fileName}
                 downloadData={testReport.url}
               />
             </>

--- a/src/am/components/Tests/Row.js
+++ b/src/am/components/Tests/Row.js
@@ -29,7 +29,10 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const TestRow = ({ test }) => {
-  const { id: testId, powderReference, overallResult: testStatus } = test
+  const {
+    id: testId,
+    metadata: { powderReference, overallResult },
+  } = test
   const classes = useStyles()
   const readTests = useSelector((state) => state.readTests)
 
@@ -54,7 +57,7 @@ const TestRow = ({ test }) => {
           <Typography>{powderReference}</Typography>
         </Grid>
         <Grid item xs={4} className={`${classes.rowItem}`}>
-          <TestStatus testStatus={testStatus} />
+          <TestStatus testStatus={overallResult} />
         </Grid>
       </Grid>
     </Paper>

--- a/src/am/components/Tests/index.js
+++ b/src/am/components/Tests/index.js
@@ -12,7 +12,7 @@ const LabTests = () => {
   const params = useParams()
   const labTests = useSelector((state) =>
     state.labTests.filter(
-      (test) => test.type === 'POWDER_TEST' && test.status === 'result'
+      ({ type, status }) => type === 'POWDER_TEST' && status === 'result'
     )
   )
 

--- a/src/am/components/Tests/index.js
+++ b/src/am/components/Tests/index.js
@@ -11,7 +11,9 @@ import Header from '../Header'
 const LabTests = () => {
   const params = useParams()
   const labTests = useSelector((state) =>
-    state.labTests.filter(({ type }) => type === 'PowderTestResult')
+    state.labTests.filter(
+      (test) => test.type === 'POWDER_TEST' && test.status === 'result'
+    )
   )
 
   const selectedTest = params.testId

--- a/src/am/components/Tests/index.js
+++ b/src/am/components/Tests/index.js
@@ -8,11 +8,14 @@ import TestRow from './Row'
 import TestDetail from './Detail'
 import Header from '../Header'
 
+import { tokenTypes, powderTestStatus } from '../../../utils'
+
 const LabTests = () => {
   const params = useParams()
   const labTests = useSelector((state) =>
     state.labTests.filter(
-      ({ type, status }) => type === 'POWDER_TEST' && status === 'result'
+      ({ type, status }) =>
+        type === tokenTypes.powderTest && status === powderTestStatus.result
     )
   )
 

--- a/src/am/components/Tests/index.js
+++ b/src/am/components/Tests/index.js
@@ -14,7 +14,7 @@ const LabTests = () => {
   const params = useParams()
   const labTests = useSelector((state) =>
     state.labTests.filter(
-      ({ type, status }) =>
+      ({ metadata: { type, status } }) =>
         type === tokenTypes.powderTest && status === powderTestStatus.result
     )
   )

--- a/src/customer/components/Download.js
+++ b/src/customer/components/Download.js
@@ -14,37 +14,13 @@ const Download = ({ name, downloadData }) => {
   const [url, setURL] = useState('')
 
   useEffect(() => {
-    const dataURItoObjectURL = (dataURI) => {
-      if (!dataURI) {
-        return ''
-      } else {
-        const [dataURIHeader, dataBase64] = dataURI.split(',')
-
-        const byteString = atob(dataBase64)
-        const mimeString = dataURIHeader.split(':')[1].split(';')[0]
-
-        const ab = new ArrayBuffer(byteString.length)
-        const ia = new Uint8Array(ab)
-
-        for (let counter = 0; counter < byteString.length; counter++) {
-          ia[counter] = byteString.charCodeAt(counter)
-        }
-
-        const blob = new Blob([ab], { type: mimeString })
-        const url = URL.createObjectURL(blob)
-
-        return url
-      }
-    }
-
-    const url = dataURItoObjectURL(downloadData)
-    setURL(url)
+    setURL(downloadData)
 
     return () => {
       URL.revokeObjectURL(url)
       setURL('')
     }
-  }, [downloadData, setURL])
+  }, [downloadData, url])
 
   return (
     <Box>

--- a/src/customer/components/DownloadButton.js
+++ b/src/customer/components/DownloadButton.js
@@ -36,7 +36,6 @@ const DownloadButton = (props) => {
     )
   )
   const classes = useStyles()
-  console.log(selectedLabTest)
   if (
     statusIndex &&
     selectedLabTest &&

--- a/src/customer/components/DownloadButton.js
+++ b/src/customer/components/DownloadButton.js
@@ -4,6 +4,8 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 
+import { tokenTypes, powderTestStatus } from '../../utils'
+
 const useStyles = makeStyles({
   download: {
     width: 405,
@@ -25,8 +27,8 @@ const DownloadButton = (props) => {
   const selectedLabTest = useSelector((state) =>
     state.labTests.find(
       ({ powderId, type, status }) =>
-        type === 'POWDER_TEST' &&
-        status === 'result' &&
+        type === tokenTypes.powderTest &&
+        status === powderTestStatus.result &&
         powderId === orderPowderId
     )
   )

--- a/src/customer/components/DownloadButton.js
+++ b/src/customer/components/DownloadButton.js
@@ -24,8 +24,10 @@ const DownloadButton = (props) => {
   const { statusIndex, orderPowderId } = props
   const selectedLabTest = useSelector((state) =>
     state.labTests.find(
-      ({ powderId, type }) =>
-        type === 'PowderTestResult' && powderId === orderPowderId
+      ({ powderId, type, status }) =>
+        type === 'POWDER_TEST' &&
+        status === 'result' &&
+        powderId === orderPowderId
     )
   )
   const classes = useStyles()
@@ -60,8 +62,8 @@ const DownloadButton = (props) => {
         </Grid>
         <Grid item xs={4}>
           <Download
-            name="Powder test results.pdf"
-            downloadData={selectedLabTest.testReport}
+            name={selectedLabTest.testReport.name}
+            downloadData={selectedLabTest.testReport.url}
           />
         </Grid>
       </Grid>

--- a/src/customer/components/DownloadButton.js
+++ b/src/customer/components/DownloadButton.js
@@ -20,21 +20,28 @@ const useStyles = makeStyles({
   failText: {
     color: 'red',
   },
+  noReportText: {
+    textAlign: 'right',
+  },
 })
 
 const DownloadButton = (props) => {
   const { statusIndex, orderPowderId } = props
   const selectedLabTest = useSelector((state) =>
     state.labTests.find(
-      ({ powderId, type, status }) =>
+      ({ metadata: { type, status, powderId } }) =>
         type === tokenTypes.powderTest &&
         status === powderTestStatus.result &&
         powderId === orderPowderId
     )
   )
   const classes = useStyles()
-
-  if (statusIndex && selectedLabTest && selectedLabTest.testReport) {
+  console.log(selectedLabTest)
+  if (
+    statusIndex &&
+    selectedLabTest &&
+    selectedLabTest.metadata.overallResult
+  ) {
     return (
       <Grid
         container
@@ -53,20 +60,28 @@ const DownloadButton = (props) => {
             <Typography
               variant="body2"
               className={
-                selectedLabTest.overallResult === 'passed'
+                selectedLabTest.metadata.overallResult === 'passed'
                   ? classes.passText
                   : classes.failText
               }
             >
-              {selectedLabTest.overallResult === 'passed' ? 'PASS' : 'FAIL'}
+              {selectedLabTest.metadata.overallResult === 'passed'
+                ? 'PASS'
+                : 'FAIL'}
             </Typography>
           </Grid>
         </Grid>
         <Grid item xs={4}>
-          <Download
-            name={selectedLabTest.testReport.name}
-            downloadData={selectedLabTest.testReport.url}
-          />
+          {selectedLabTest.metadata.testReport ? (
+            <Download
+              name={selectedLabTest.metadata.testReport.fileName}
+              downloadData={selectedLabTest.metadata.testReport.url}
+            />
+          ) : (
+            <Typography variant="body2" className={classes.noReportText}>
+              No report
+            </Typography>
+          )}
         </Grid>
       </Grid>
     )

--- a/src/customer/components/OrderStatusProgressBar.js
+++ b/src/customer/components/OrderStatusProgressBar.js
@@ -37,8 +37,10 @@ const OrderStatusProgressBar = (props) => {
 
   const selectedLabTest = useSelector((state) =>
     state.labTests.find(
-      ({ powderId, type }) =>
-        type === 'PowderTestResult' && powderId === orderPowderId
+      ({ powderId, type, status }) =>
+        type === 'POWDER_TEST' &&
+        status === 'result' &&
+        powderId === orderPowderId
     )
   )
 

--- a/src/customer/components/OrderStatusProgressBar.js
+++ b/src/customer/components/OrderStatusProgressBar.js
@@ -34,16 +34,18 @@ const useStyles = makeStyles({
 })
 
 const OrderStatusProgressBar = (props) => {
+  console.log(props)
   const { orderType, orderPowderId } = props
 
   const selectedLabTest = useSelector((state) =>
     state.labTests.find(
-      ({ powderId, type, status }) =>
+      ({ metadata: { type, status, powderId } }) =>
         type === tokenTypes.powderTest &&
         status === powderTestStatus.result &&
         powderId === orderPowderId
     )
   )
+  console.log(selectedLabTest)
 
   const classes = useStyles()
 

--- a/src/customer/components/OrderStatusProgressBar.js
+++ b/src/customer/components/OrderStatusProgressBar.js
@@ -34,7 +34,6 @@ const useStyles = makeStyles({
 })
 
 const OrderStatusProgressBar = (props) => {
-  console.log(props)
   const { orderType, orderPowderId } = props
 
   const selectedLabTest = useSelector((state) =>
@@ -45,7 +44,6 @@ const OrderStatusProgressBar = (props) => {
         powderId === orderPowderId
     )
   )
-  console.log(selectedLabTest)
 
   const classes = useStyles()
 

--- a/src/customer/components/OrderStatusProgressBar.js
+++ b/src/customer/components/OrderStatusProgressBar.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 
 import DownloadButton from './DownloadButton'
 import ProgressBarSelector from './ProgressBarSelector'
+import { tokenTypes, powderTestStatus } from '../../utils'
 
 const useStyles = makeStyles({
   backButton: {
@@ -38,8 +39,8 @@ const OrderStatusProgressBar = (props) => {
   const selectedLabTest = useSelector((state) =>
     state.labTests.find(
       ({ powderId, type, status }) =>
-        type === 'POWDER_TEST' &&
-        status === 'result' &&
+        type === tokenTypes.powderTest &&
+        status === powderTestStatus.result &&
         powderId === orderPowderId
     )
   )

--- a/src/features/labTestsSlice.js
+++ b/src/features/labTestsSlice.js
@@ -6,10 +6,10 @@ export const labTestsSlice = createSlice({
   reducers: {
     upsertLabTest: {
       reducer(state, action) {
-        // tokens for new assets have matching id and original_id
         const labTest = state.find(
           ({ id }) => id === action.payload.original_id
         )
+        // tokens for new assets have matching id and original_id
         if (action.payload.id === action.payload.original_id) {
           if (!labTest) {
             state.push(action.payload)

--- a/src/features/labTestsSlice.js
+++ b/src/features/labTestsSlice.js
@@ -7,7 +7,7 @@ export const labTestsSlice = createSlice({
     upsertLabTest: {
       reducer(state, action) {
         const labTest = state.find(
-          ({ id }) => id === action.payload.original_id
+          ({ original_id }) => original_id === action.payload.original_id
         )
         // tokens for new assets have matching id and original_id
         if (action.payload.id === action.payload.original_id) {
@@ -16,7 +16,10 @@ export const labTestsSlice = createSlice({
           }
         } else {
           if (labTest) {
-            Object.assign(labTest, action.payload)
+            labTest.id = action.payload.id
+            labTest.original_id = action.payload.original_id
+            Object.assign(labTest.roles, action.payload.roles)
+            Object.assign(labTest.metadata, action.payload.metadata)
           } else {
             console.error(
               `Error cannot find token with id ${action.payload.original_id}`

--- a/src/features/labTestsSlice.js
+++ b/src/features/labTestsSlice.js
@@ -4,21 +4,24 @@ export const labTestsSlice = createSlice({
   name: 'labTests',
   initialState: [],
   reducers: {
-    addLabTest: {
+    upsertLabTest: {
       reducer(state, action) {
-        const labTest = state.find(({ id }) => id === action.payload.id)
-        if (!labTest) {
-          state.push(action.payload)
-        }
-      },
-    },
-    updateLabTest: {
-      reducer(state, action) {
-        const test = state.find(({ id }) => id === action.payload.id)
-        if (test) {
-          Object.assign(test, action.payload)
+        // tokens for new assets have matching id and original_id
+        const labTest = state.find(
+          ({ id }) => id === action.payload.original_id
+        )
+        if (action.payload.id === action.payload.original_id) {
+          if (!labTest) {
+            state.push(action.payload)
+          }
         } else {
-          console.error(`Error cannot find token with id ${action.payload.id}`)
+          if (labTest) {
+            Object.assign(labTest, action.payload)
+          } else {
+            console.error(
+              `Error cannot find token with id ${action.payload.original_id}`
+            )
+          }
         }
       },
     },
@@ -27,6 +30,6 @@ export const labTestsSlice = createSlice({
 
 export const { actions, reducer } = labTestsSlice
 
-export const { addLabTest, updateLabTest } = actions
+export const { upsertLabTest } = actions
 
 export default reducer

--- a/src/laboratory/components/Attachment.js
+++ b/src/laboratory/components/Attachment.js
@@ -39,41 +39,17 @@ const useStyles = makeStyles({
 })
 
 const Attachment = ({ name, downloadData }) => {
-
   const classes = useStyles()
   const [url, setURL] = useState('')
 
   useEffect(() => {
-    // const dataURItoObjectURL = (dataURI) => {
-    //   if (!dataURI) {
-    //     return ''
-    //   } else {
-    //     const [dataURIHeader, dataBase64] = dataURI.split(',')
-
-    //     const byteString = atob(dataBase64)
-    //     const mimeString = dataURIHeader.split(':')[1].split(';')[0]
-
-    //     const ab = new ArrayBuffer(byteString.length)
-    //     const ia = new Uint8Array(ab)
-    //     for (let i = 0; i < byteString.length; i++) {
-    //       ia[i] = byteString.charCodeAt(i)
-    //     }
-
-    //     const blob = new Blob([ab], { type: mimeString })
-    //     const url = URL.createObjectURL(blob)
-
-    //     return url
-    //   }
-    // }
-
-    //const url = dataURItoObjectURL(downloadData)
     setURL(downloadData)
 
     return () => {
       URL.revokeObjectURL(url)
       setURL('')
     }
-  }, [downloadData, setURL])
+  }, [downloadData, url])
 
   return (
     <Box className={classes.attachmentContainer}>

--- a/src/laboratory/components/Attachment.js
+++ b/src/laboratory/components/Attachment.js
@@ -39,34 +39,36 @@ const useStyles = makeStyles({
 })
 
 const Attachment = ({ name, downloadData }) => {
+  if (downloadData) console.log(downloadData.type)
+
   const classes = useStyles()
   const [url, setURL] = useState('')
 
   useEffect(() => {
-    const dataURItoObjectURL = (dataURI) => {
-      if (!dataURI) {
-        return ''
-      } else {
-        const [dataURIHeader, dataBase64] = dataURI.split(',')
+    // const dataURItoObjectURL = (dataURI) => {
+    //   if (!dataURI) {
+    //     return ''
+    //   } else {
+    //     const [dataURIHeader, dataBase64] = dataURI.split(',')
 
-        const byteString = atob(dataBase64)
-        const mimeString = dataURIHeader.split(':')[1].split(';')[0]
+    //     const byteString = atob(dataBase64)
+    //     const mimeString = dataURIHeader.split(':')[1].split(';')[0]
 
-        const ab = new ArrayBuffer(byteString.length)
-        const ia = new Uint8Array(ab)
-        for (let i = 0; i < byteString.length; i++) {
-          ia[i] = byteString.charCodeAt(i)
-        }
+    //     const ab = new ArrayBuffer(byteString.length)
+    //     const ia = new Uint8Array(ab)
+    //     for (let i = 0; i < byteString.length; i++) {
+    //       ia[i] = byteString.charCodeAt(i)
+    //     }
 
-        const blob = new Blob([ab], { type: mimeString })
-        const url = URL.createObjectURL(blob)
+    //     const blob = new Blob([ab], { type: mimeString })
+    //     const url = URL.createObjectURL(blob)
 
-        return url
-      }
-    }
+    //     return url
+    //   }
+    // }
 
-    const url = dataURItoObjectURL(downloadData)
-    setURL(url)
+    //const url = dataURItoObjectURL(downloadData)
+    setURL(downloadData)
 
     return () => {
       URL.revokeObjectURL(url)

--- a/src/laboratory/components/Attachment.js
+++ b/src/laboratory/components/Attachment.js
@@ -39,7 +39,6 @@ const useStyles = makeStyles({
 })
 
 const Attachment = ({ name, downloadData }) => {
-  if (downloadData) console.log(downloadData.type)
 
   const classes = useStyles()
   const [url, setURL] = useState('')

--- a/src/laboratory/components/LabTestDetails.js
+++ b/src/laboratory/components/LabTestDetails.js
@@ -6,11 +6,13 @@ import LabTestDetailsOverview from './LabTestDetailsOverview'
 const LabTestDetails = (props) => {
   const {
     id,
-    powderReference,
-    requiredTests,
-    overallResult,
-    testReason,
-    testReport,
+    metadata: {
+      powderReference,
+      requiredTests,
+      overallResult,
+      testReason,
+      testReport,
+    },
   } = props
   const [isEditMode, setIsEditMode] = useState(false)
   return !isEditMode ? (

--- a/src/laboratory/components/LabTestDetailsEdit.js
+++ b/src/laboratory/components/LabTestDetailsEdit.js
@@ -14,7 +14,7 @@ import { useDropzone } from 'react-dropzone'
 import Attachment from './Attachment'
 import images from '../../images'
 import LabTestRow from './LabTestRow'
-import { identities, useApi } from '../../utils'
+import { identities, useApi, tokenTypes } from '../../utils'
 
 const useStyles = makeStyles({
   root: { marginTop: '40px', marginBottom: '40px', padding: '8px' },
@@ -81,7 +81,7 @@ const LabTestDetailsEdit = ({ id }) => {
       {
         roles: { Owner: identities.am },
         metadata: {
-          type: { type: 'LITERAL', value: 'POWDER_TEST' },
+          type: { type: 'LITERAL', value: tokenTypes.powderTest },
           status: { type: 'LITERAL', value: 'result' },
           overallResult: { type: 'LITERAL', value: labTestPassOrFail },
           ...(files.reportFile

--- a/src/laboratory/components/LabTestDetailsEdit.js
+++ b/src/laboratory/components/LabTestDetailsEdit.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import {
   Button,
@@ -16,7 +15,6 @@ import Attachment from './Attachment'
 import images from '../../images'
 import LabTestRow from './LabTestRow'
 import { identities, useApi } from '../../utils'
-import { updateLabTest } from '../../features/labTestsSlice'
 
 const useStyles = makeStyles({
   root: { marginTop: '40px', marginBottom: '40px', padding: '8px' },
@@ -46,7 +44,6 @@ const LabTestDetailsEdit = ({ id }) => {
   const [reportFile, setReportFile] = useState(null)
 
   const api = useApi()
-  const dispatch = useDispatch()
   const navigate = useNavigate()
 
   const { getRootProps, getInputProps } = useDropzone({
@@ -57,8 +54,8 @@ const LabTestDetailsEdit = ({ id }) => {
       const images = ['png', 'gif', 'jpg']
       const type = images.includes(ext) ? 'image' : 'application'
       const reader = new FileReader()
-      reader.onabort = () => console.log('File reading was aborted')
-      reader.onerror = () => console.log('file reading has failed')
+      reader.onabort = () => console.error('File reading was aborted')
+      reader.onerror = () => console.error('file reading has failed')
       reader.onload = () => {
         const obj = {
           fileName: name,
@@ -131,10 +128,8 @@ const LabTestDetailsEdit = ({ id }) => {
     setIsSubmitting(true)
 
     const formData = createFormData([id], { reportFile, labTestReason })
-    const response = await api.runProcess(formData)
-    const token = { id: id, latestId: response[0] }
+    await api.runProcess(formData)
 
-    dispatch(updateLabTest(token))
     navigate('/app/tested/' + id)
   }
 

--- a/src/laboratory/components/LabTestDetailsEdit.js
+++ b/src/laboratory/components/LabTestDetailsEdit.js
@@ -37,26 +37,6 @@ const useStyles = makeStyles({
   },
 })
 
-// const u8Array2base64URI = (obj) => {
-//   const type = obj.fileType
-//   const ext = obj.fileExt
-//   const u8 = obj.fileContent
-
-//   const CHUNK_SZ = 0x8000
-//   const parsedChunks = []
-//   for (let i = 0; i < u8.length; i += CHUNK_SZ) {
-//     parsedChunks.push(
-//       String.fromCharCode.apply(null, u8.subarray(i, i + CHUNK_SZ))
-//     )
-//   }
-//   const base64 = btoa(parsedChunks.join(''))
-
-//   const prefix = 'data:' + type + '/' + ext + ';base64,'
-//   const base64URI = base64 ? prefix + base64 : ''
-
-//   return base64URI
-// }
-
 const LabTestDetailsEdit = ({ id }) => {
   const classes = useStyles()
   const [labTestPassOrFail, setLabTestPassOrFail] = useState('')

--- a/src/laboratory/components/LabTestDetailsEdit.js
+++ b/src/laboratory/components/LabTestDetailsEdit.js
@@ -99,34 +99,48 @@ const LabTestDetailsEdit = ({ id }) => {
   const handleChange = (event) => {
     setLabTestReason(event.target.value)
   }
-  const createFormData = (inputs, file) => {
+  const createFormData = (inputs, fileObject) => {
+    console.log(fileObject)
     const formData = new FormData()
     const outputs = [
       {
-        owner: identities.am,
-        metadataFile: 'file',
+        roles: { Owner: identities.am },
+        metadata: {
+          type: { type: 'LITERAL', value: 'POWDER_TEST' },
+          status: { type: 'LITERAL', value: 'result' },
+          overallResult: { type: 'LITERAL', value: labTestPassOrFail },
+          testReason: {
+            type: 'LITERAL',
+            value: labTestReason ? labTestReason : '',
+          },
+          testReport: { type: 'FILE', value: fileObject.fileName },
+        },
+        parent_index: 0,
       },
     ]
 
     formData.set('request', JSON.stringify({ inputs, outputs }))
-    formData.set('file', file, 'file')
+    formData.set('files', new Blob(fileObject.fileContent), fileObject.fileName)
 
     return formData
   }
 
   const onSubmit = async () => {
     setIsSubmitting(true)
-    const base64 = u8Array2base64URI(fileObject)
-    const fileData = {
-      type: 'PowderTestResult',
-      overallResult: labTestPassOrFail,
-      testReason: labTestReason ? labTestReason : '',
-      testReport: /*prefix +*/ base64,
-    }
-    const file = new Blob([JSON.stringify(fileData)])
-    const formData = createFormData([id], file)
+    //const base64 = u8Array2base64URI(fileObject)
+    // const fileData = {
+    //   type: 'PowderTestResult',
+    //   overallResult: labTestPassOrFail,
+    //   testReason: labTestReason ? labTestReason : '',
+    //   testReport: /*prefix +*/ base64,
+    // }
+    //const file = new Blob([JSON.stringify(fileData)])
+    const formData = createFormData([id], fileObject)
+    console.log(formData)
     const response = await api.runProcess(formData)
-    const token = { id: id, latestId: response[0], ...fileData }
+    console.log(response)
+    const token = { id: id, latestId: response[0] }
+    //const token = { id: id, latestId: response[0], ...fileData }
     dispatch(updateLabTest(token))
     navigate('/app/tested/' + id)
   }

--- a/src/laboratory/components/LabTestDetailsEdit.js
+++ b/src/laboratory/components/LabTestDetailsEdit.js
@@ -37,25 +37,25 @@ const useStyles = makeStyles({
   },
 })
 
-const u8Array2base64URI = (obj) => {
-  const type = obj.fileType
-  const ext = obj.fileExt
-  const u8 = obj.fileContent
+// const u8Array2base64URI = (obj) => {
+//   const type = obj.fileType
+//   const ext = obj.fileExt
+//   const u8 = obj.fileContent
 
-  const CHUNK_SZ = 0x8000
-  const parsedChunks = []
-  for (let i = 0; i < u8.length; i += CHUNK_SZ) {
-    parsedChunks.push(
-      String.fromCharCode.apply(null, u8.subarray(i, i + CHUNK_SZ))
-    )
-  }
-  const base64 = btoa(parsedChunks.join(''))
+//   const CHUNK_SZ = 0x8000
+//   const parsedChunks = []
+//   for (let i = 0; i < u8.length; i += CHUNK_SZ) {
+//     parsedChunks.push(
+//       String.fromCharCode.apply(null, u8.subarray(i, i + CHUNK_SZ))
+//     )
+//   }
+//   const base64 = btoa(parsedChunks.join(''))
 
-  const prefix = 'data:' + type + '/' + ext + ';base64,'
-  const base64URI = base64 ? prefix + base64 : ''
+//   const prefix = 'data:' + type + '/' + ext + ';base64,'
+//   const base64URI = base64 ? prefix + base64 : ''
 
-  return base64URI
-}
+//   return base64URI
+// }
 
 const LabTestDetailsEdit = ({ id }) => {
   const classes = useStyles()
@@ -80,12 +80,11 @@ const LabTestDetailsEdit = ({ id }) => {
       reader.onabort = () => console.log('File reading was aborted')
       reader.onerror = () => console.log('file reading has failed')
       reader.onload = () => {
-        const u8 = new Uint8Array(reader.result)
         const obj = {
           fileName: name,
           fileExt: ext,
           fileType: type,
-          fileContent: u8,
+          fileContent: reader.result,
         }
         setFileObject(obj)
       }
@@ -120,7 +119,10 @@ const LabTestDetailsEdit = ({ id }) => {
     ]
 
     formData.set('request', JSON.stringify({ inputs, outputs }))
-    formData.set('files', new Blob(fileObject.fileContent), fileObject.fileName)
+    const blob = new Blob([fileObject.fileContent], {
+      type: fileObject.fileType,
+    })
+    formData.set('files', blob, fileObject.fileName)
 
     return formData
   }
@@ -194,7 +196,7 @@ const LabTestDetailsEdit = ({ id }) => {
                 </Typography>
                 <Attachment
                   name={fileObject.fileName}
-                  downloadData={u8Array2base64URI(fileObject)}
+                  downloadData={fileObject}
                 />
               </>
             )}

--- a/src/laboratory/components/LabTestDetailsOverview.js
+++ b/src/laboratory/components/LabTestDetailsOverview.js
@@ -73,7 +73,7 @@ const LabTestDetailsOverview = ({
             <Grid container className={classes.border}>
               <LabTestRow title={'Test Results'} value={''} bold={true} />
               <LabTestRow title={'Passed/Failed'} value={overallResult} />
-              {testReason?.url ? (
+              {testReason ? (
                 <Attachment
                   name={testReason.name}
                   downloadData={testReason.url}
@@ -81,7 +81,7 @@ const LabTestDetailsOverview = ({
               ) : (
                 <LabTestRow title={'Reason'} value="No reason given" />
               )}
-              {testReport?.url ? (
+              {testReport ? (
                 <Attachment
                   name={testReport.name}
                   downloadData={testReport.url}

--- a/src/laboratory/components/LabTestDetailsOverview.js
+++ b/src/laboratory/components/LabTestDetailsOverview.js
@@ -22,6 +22,7 @@ const LabTestDetailsOverview = ({
   changeIsEditMode,
 }) => {
   const classes = useStyles()
+  console.log('testReport', testReport)
   return (
     <Grid container spacing={0} className={classes.root}>
       <Grid xs={12}>
@@ -76,8 +77,8 @@ const LabTestDetailsOverview = ({
               <LabTestRow title={'Reason'} value={testReason} />
               {testReport ? (
                 <Attachment
-                  name="PowderTestingResults.pdf"
-                  downloadData={testReport}
+                  name={testReport.name}
+                  downloadData={testReport.url}
                 />
               ) : (
                 <></>

--- a/src/laboratory/components/LabTestDetailsOverview.js
+++ b/src/laboratory/components/LabTestDetailsOverview.js
@@ -22,7 +22,6 @@ const LabTestDetailsOverview = ({
   changeIsEditMode,
 }) => {
   const classes = useStyles()
-  console.log('testReport', testReport)
   return (
     <Grid container spacing={0} className={classes.root}>
       <Grid xs={12}>
@@ -74,14 +73,21 @@ const LabTestDetailsOverview = ({
             <Grid container className={classes.border}>
               <LabTestRow title={'Test Results'} value={''} bold={true} />
               <LabTestRow title={'Passed/Failed'} value={overallResult} />
-              <LabTestRow title={'Reason'} value={testReason} />
-              {testReport ? (
+              {testReason?.url ? (
+                <Attachment
+                  name={testReason.name}
+                  downloadData={testReason.url}
+                />
+              ) : (
+                <LabTestRow title={'Reason'} value="No reason given" />
+              )}
+              {testReport?.url ? (
                 <Attachment
                   name={testReport.name}
                   downloadData={testReport.url}
                 />
               ) : (
-                <></>
+                <LabTestRow title={'Report'} value="No report" />
               )}
             </Grid>
           ) : (

--- a/src/laboratory/components/LabTestDetailsOverview.js
+++ b/src/laboratory/components/LabTestDetailsOverview.js
@@ -75,7 +75,7 @@ const LabTestDetailsOverview = ({
               <LabTestRow title={'Passed/Failed'} value={overallResult} />
               {testReason ? (
                 <Attachment
-                  name={testReason.name}
+                  name={testReason.fileName}
                   downloadData={testReason.url}
                 />
               ) : (
@@ -83,7 +83,7 @@ const LabTestDetailsOverview = ({
               )}
               {testReport ? (
                 <Attachment
-                  name={testReport.name}
+                  name={testReport.fileName}
                   downloadData={testReport.url}
                 />
               ) : (

--- a/src/laboratory/components/LabTestsItem.js
+++ b/src/laboratory/components/LabTestsItem.js
@@ -34,11 +34,10 @@ const useStyles = makeStyles(() => ({
 }))
 
 const LabTestsItem = (props) => {
-  const { selectedId, status, id, powderReference } = props
-  console.log(props)
-  const tested = status !== 'request'
+  const { selectedId, type, sent, status, id, powderReference } = props
+  const tested = type === 'PowderTestResult' || status === 'result'
   const selected = selectedId === id ? true : false
-  const statusText = tested ? 'tested' : 'requested'
+  const statusText = tested ? 'tested' : sent ? 'sent' : 'requested'
   const classes = useStyles()
   return (
     <NavLink

--- a/src/laboratory/components/LabTestsItem.js
+++ b/src/laboratory/components/LabTestsItem.js
@@ -34,10 +34,11 @@ const useStyles = makeStyles(() => ({
 }))
 
 const LabTestsItem = (props) => {
-  const { selectedId, type, sent, id, powderReference } = props
-  const tested = type === 'PowderTestResult'
+  const { selectedId, status, id, powderReference } = props
+  console.log(props)
+  const tested = status !== 'request'
   const selected = selectedId === id ? true : false
-  const status = tested ? 'tested' : sent ? 'sent' : 'requested'
+  const statusText = tested ? 'tested' : 'requested'
   const classes = useStyles()
   return (
     <NavLink
@@ -54,7 +55,7 @@ const LabTestsItem = (props) => {
             <Typography>{powderReference}</Typography>
           </Grid>
           <Grid item xs={4}>
-            <LabTestStatus labTestStatus={status} />
+            <LabTestStatus labTestStatus={statusText} />
           </Grid>
         </Grid>
       </Paper>

--- a/src/laboratory/components/LabTestsItem.js
+++ b/src/laboratory/components/LabTestsItem.js
@@ -4,6 +4,7 @@ import { NavLink } from 'react-router-dom'
 import { Paper, Typography, Grid } from '@material-ui/core'
 
 import LabTestStatus from './LabTestStatus'
+import { tokenTypes, powderTestStatus } from '../../utils'
 
 const useStyles = makeStyles(() => ({
   paperNonActive: {
@@ -35,7 +36,7 @@ const useStyles = makeStyles(() => ({
 
 const LabTestsItem = (props) => {
   const { selectedId, type, sent, status, id, powderReference } = props
-  const tested = type === 'POWDER_TEST' && status === 'result'
+  const tested = type === tokenTypes.powderTest && status === powderTestStatus.result
   const selected = selectedId === id ? true : false
   const statusText = tested ? 'tested' : sent ? 'sent' : 'requested'
   const classes = useStyles()

--- a/src/laboratory/components/LabTestsItem.js
+++ b/src/laboratory/components/LabTestsItem.js
@@ -35,14 +35,20 @@ const useStyles = makeStyles(() => ({
 }))
 
 const LabTestsItem = (props) => {
-  const { selectedId, type, sent, status, id, powderReference } = props
-  const tested = type === tokenTypes.powderTest && status === powderTestStatus.result
-  const selected = selectedId === id ? true : false
+  const {
+    selectedId,
+    metadata: { type, status, powderReference },
+    sent,
+    original_id,
+  } = props
+  const tested =
+    type === tokenTypes.powderTest && status === powderTestStatus.result
+  const selected = selectedId === original_id ? true : false
   const statusText = tested ? 'tested' : sent ? 'sent' : 'requested'
   const classes = useStyles()
   return (
     <NavLink
-      to={(tested ? '/app/tested/' : '/app/requests/') + id}
+      to={(tested ? '/app/tested/' : '/app/requests/') + original_id}
       className={classes.navButton}
       activeClassName={classes.navActive}
     >

--- a/src/laboratory/components/LabTestsItem.js
+++ b/src/laboratory/components/LabTestsItem.js
@@ -35,7 +35,7 @@ const useStyles = makeStyles(() => ({
 
 const LabTestsItem = (props) => {
   const { selectedId, type, sent, status, id, powderReference } = props
-  const tested = type === 'PowderTestResult' || status === 'result'
+  const tested = type === 'POWDER_TEST' && status === 'result'
   const selected = selectedId === id ? true : false
   const statusText = tested ? 'tested' : sent ? 'sent' : 'requested'
   const classes = useStyles()

--- a/src/laboratory/components/Request.js
+++ b/src/laboratory/components/Request.js
@@ -15,7 +15,9 @@ const RequestsAndRequest = () => {
   const selectedId = useParams().testId * 1 || null
   const laboratoryTests = useSelector((state) =>
     state.labTests.filter(
-      (o) => o.type === 'PowderTestRequest' && o.owner === identities.current
+      ({ roles, metadata }) =>
+        metadata.type === 'PowderTestRequest' &&
+        roles.Owner === identities.current // temp, change to roles.lab === identities.current when PowderTestRequest updated with new roles
     )
   )
   const selectedTest = laboratoryTests.find((o) => o.id === selectedId)
@@ -33,7 +35,7 @@ const RequestsAndRequest = () => {
             </LabTestsItemsWrapper>
           </Grid>
           <Grid item xs={6} xs-offset={1}>
-            {selectedId ? <LabTestDetails {...selectedTest} /> : null}
+            {selectedTest ? <LabTestDetails {...selectedTest} /> : null}
           </Grid>
           <Grid item xs={1} />
         </LabTestsWrapper>

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -15,7 +15,10 @@ const Tested = () => {
   const selectedId = useParams().testId * 1 || null
   const laboratoryTests = useSelector((state) =>
     state.labTests.filter(
-      (o) => o.type === 'PowderTestResult' && o.owner === identities.current
+      (o) =>
+        o.type === 'POWDER_TEST' &&
+        o.status === 'result' &&
+        o.owner === identities.current
     )
   )
   const selectedTest = laboratoryTests.find((o) => o.id === selectedId)

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -15,10 +15,10 @@ const Tested = () => {
   const selectedId = useParams().testId * 1 || null
   const laboratoryTests = useSelector((state) =>
     state.labTests.filter(
-      ({ type, status, owner }) =>
+      ({ type, status, roles }) =>
         type === 'POWDER_TEST' &&
         status === 'result' &&
-        owner === identities.current
+        roles.Owner === identities.am // temp, change to roles.lab === identities.current when PowderTestRequest updated with new roles
     )
   )
   const selectedTest = laboratoryTests.find((o) => o.id === selectedId)

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -9,15 +9,15 @@ import LabTestsItem from './LabTestsItem'
 import LabTestsItemsWrapper from './LabTestsItemsWrapper'
 import LabTestsSearch from './LabTestsSearch'
 import LabTestsWrapper from './LabTestsWrapper'
-import { identities } from '../../utils'
+import { identities, tokenTypes, powderTestStatus } from '../../utils'
 
 const Tested = () => {
   const selectedId = useParams().testId * 1 || null
   const laboratoryTests = useSelector((state) =>
     state.labTests.filter(
       ({ type, status, roles }) =>
-        type === 'POWDER_TEST' &&
-        status === 'result' &&
+        type === tokenTypes.powderTest &&
+        status === powderTestStatus.result &&
         roles.Owner === identities.am // temp, change to roles.lab === identities.current when PowderTestRequest updated with new roles
     )
   )

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -22,7 +22,6 @@ const Tested = () => {
     )
   )
   const selectedTest = laboratoryTests.find((o) => o.id === selectedId)
-  console.log(selectedTest)
   return (
     <>
       {laboratoryTests.length ? (

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -22,6 +22,7 @@ const Tested = () => {
     )
   )
   const selectedTest = laboratoryTests.find((o) => o.id === selectedId)
+  console.log(selectedTest)
   return (
     <>
       {laboratoryTests.length ? (

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -15,10 +15,10 @@ const Tested = () => {
   const selectedId = useParams().testId * 1 || null
   const laboratoryTests = useSelector((state) =>
     state.labTests.filter(
-      (o) =>
-        o.type === 'POWDER_TEST' &&
-        o.status === 'result' &&
-        o.owner === identities.current
+      ({ type, status, owner }) =>
+        type === 'POWDER_TEST' &&
+        status === 'result' &&
+        owner === identities.current
     )
   )
   const selectedTest = laboratoryTests.find((o) => o.id === selectedId)

--- a/src/laboratory/components/Tested.js
+++ b/src/laboratory/components/Tested.js
@@ -15,13 +15,13 @@ const Tested = () => {
   const selectedId = useParams().testId * 1 || null
   const laboratoryTests = useSelector((state) =>
     state.labTests.filter(
-      ({ type, status, roles }) =>
+      ({ roles, metadata: { type, status } }) =>
         type === tokenTypes.powderTest &&
         status === powderTestStatus.result &&
         roles.Owner === identities.am // temp, change to roles.lab === identities.current when PowderTestRequest updated with new roles
     )
   )
-  const selectedTest = laboratoryTests.find((o) => o.id === selectedId)
+  const selectedTest = laboratoryTests.find((l) => l.original_id === selectedId)
   return (
     <>
       {laboratoryTests.length ? (
@@ -36,7 +36,7 @@ const Tested = () => {
             </LabTestsItemsWrapper>
           </Grid>
           <Grid item xs={6} xs-offset={1} spacing={1}>
-            {selectedId ? <LabTestDetails {...selectedTest} /> : null}
+            {selectedTest ? <LabTestDetails {...selectedTest} /> : null}
           </Grid>
           <Grid item xs={1} />
         </LabTestsWrapper>

--- a/src/shared/BlockchainWatcher.js
+++ b/src/shared/BlockchainWatcher.js
@@ -4,7 +4,7 @@ import { addOrder, updateOrder } from '../features/ordersSlice'
 import { upsertPowder } from '../features/powdersSlice'
 import { upsertLabTest } from '../features/labTestsSlice'
 
-import { useApi } from '../utils'
+import { useApi, tokenTypes } from '../utils'
 
 // will search for the equivalent token that exists in the list `items`
 // to the passed `token`
@@ -109,7 +109,7 @@ const BlockchainWatcher = ({ children }) => {
               )
               break
             case 'PowderTestRequest':
-            case 'POWDER_TEST':
+            case tokenTypes.powderTest:
               console.log(token)
               dispatch(
                 upsertLabTest({

--- a/src/shared/BlockchainWatcher.js
+++ b/src/shared/BlockchainWatcher.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { addOrder, updateOrder } from '../features/ordersSlice'
 import { upsertPowder } from '../features/powdersSlice'
-import { addLabTest, updateLabTest } from '../features/labTestsSlice'
+import { upsertLabTest } from '../features/labTestsSlice'
 
 import { useApi } from '../utils'
 
@@ -109,22 +109,14 @@ const BlockchainWatcher = ({ children }) => {
               )
               break
             case 'PowderTestRequest':
-              dispatch(
-                addLabTest({
-                  id: token.id,
-                  latestId: token.id,
-                  owner: token.roles.Owner,
-                  latestOwner: token.roles.Owner,
-                  ...token.metadata,
-                })
-              )
-              break
             case 'POWDER_TEST':
+              console.log(token)
               dispatch(
-                updateLabTest({
-                  id: token.original_id,
-                  latestId: token.id,
-                  latestOwner: token.roles.Owner,
+                upsertLabTest({
+                  id: token.id,
+                  original_id: token.original_id,
+                  owner: token.roles.Owner,
+                  roles: token.roles,
                   ...token.metadata,
                 })
               )

--- a/src/shared/BlockchainWatcher.js
+++ b/src/shared/BlockchainWatcher.js
@@ -119,20 +119,10 @@ const BlockchainWatcher = ({ children }) => {
                 })
               )
               break
-            case 'PowderTestResult':
-              dispatch(
-                updateLabTest({
-                  id: findOriginalId(labTests, token),
-                  latestId: token.id,
-                  latestOwner: token.roles.Owner,
-                  ...token.metadata,
-                })
-              )
-              break
             case 'POWDER_TEST':
               dispatch(
                 updateLabTest({
-                  id: findOriginalId(labTests, token),
+                  id: token.original_id,
                   latestId: token.id,
                   latestOwner: token.roles.Owner,
                   ...token.metadata,

--- a/src/shared/BlockchainWatcher.js
+++ b/src/shared/BlockchainWatcher.js
@@ -68,8 +68,8 @@ const BlockchainWatcher = ({ children }) => {
                 addOrder({
                   id: token.id,
                   latestId: token.id,
-                  owner: token.roles.Admin,
-                  latestOwner: token.roles.Admin,
+                  owner: token.roles.Owner,
+                  latestOwner: token.roles.Owner,
                   ...token.metadata,
                 })
               )
@@ -79,7 +79,7 @@ const BlockchainWatcher = ({ children }) => {
                 updateOrder({
                   id: findOriginalId(orders, token),
                   latestId: token.id,
-                  latestOwner: token.roles.Admin,
+                  latestOwner: token.roles.Owner,
                   ...token.metadata,
                 })
               )
@@ -89,7 +89,7 @@ const BlockchainWatcher = ({ children }) => {
                 updateOrder({
                   id: findOriginalId(orders, token),
                   latestId: token.id,
-                  latestOwner: token.roles.Admin,
+                  latestOwner: token.roles.Owner,
                   ...token.metadata,
                 })
               )
@@ -101,9 +101,9 @@ const BlockchainWatcher = ({ children }) => {
                   latestId: token.id,
                   owner:
                     findOriginalId(powders, token) === token.id
-                      ? token.roles.Admin
+                      ? token.roles.Owner
                       : undefined,
-                  latestOwner: token.roles.Admin,
+                  latestOwner: token.roles.Owner,
                   ...token.metadata,
                 })
               )
@@ -113,8 +113,8 @@ const BlockchainWatcher = ({ children }) => {
                 addLabTest({
                   id: token.id,
                   latestId: token.id,
-                  owner: token.roles.Admin,
-                  latestOwner: token.roles.Admin,
+                  owner: token.roles.Owner,
+                  latestOwner: token.roles.Owner,
                   ...token.metadata,
                 })
               )
@@ -124,7 +124,17 @@ const BlockchainWatcher = ({ children }) => {
                 updateLabTest({
                   id: findOriginalId(labTests, token),
                   latestId: token.id,
-                  latestOwner: token.roles.Admin,
+                  latestOwner: token.roles.Owner,
+                  ...token.metadata,
+                })
+              )
+              break
+            case 'POWDER_TEST':
+              dispatch(
+                updateLabTest({
+                  id: findOriginalId(labTests, token),
+                  latestId: token.id,
+                  latestOwner: token.roles.Owner,
                   ...token.metadata,
                 })
               )

--- a/src/shared/BlockchainWatcher.js
+++ b/src/shared/BlockchainWatcher.js
@@ -110,14 +110,12 @@ const BlockchainWatcher = ({ children }) => {
               break
             case 'PowderTestRequest':
             case tokenTypes.powderTest:
-              console.log(token)
               dispatch(
                 upsertLabTest({
                   id: token.id,
                   original_id: token.original_id,
-                  owner: token.roles.Owner,
                   roles: token.roles,
-                  ...token.metadata,
+                  metadata: token.metadata,
                 })
               )
               break

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 import identities from './identities'
 import useApi from './vitalamApi'
 import tokenTypes from './tokenTypes'
-import powderTestStatus from './statuses'
+import { powderTestStatus } from './statuses'
 
 export { identities, useApi, tokenTypes, powderTestStatus }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,6 @@
 import identities from './identities'
 import useApi from './vitalamApi'
+import tokenTypes from './tokenTypes'
+import powderTestStatus from './statuses'
 
-export { identities, useApi }
+export { identities, useApi, tokenTypes, powderTestStatus }

--- a/src/utils/statuses.js
+++ b/src/utils/statuses.js
@@ -1,0 +1,5 @@
+const powderTestStatus = {
+  result: 'result',
+}
+
+export { powderTestStatus }

--- a/src/utils/tokenTypes.js
+++ b/src/utils/tokenTypes.js
@@ -1,0 +1,5 @@
+const tokenTypes = {
+  powderTest: 'POWDER_TEST',
+}
+
+export default tokenTypes

--- a/src/utils/vitalamApi.js
+++ b/src/utils/vitalamApi.js
@@ -54,8 +54,17 @@ const useNewFetchWrapper = () => {
       return request.text()
     } else {
       const file = await request.blob()
-      console.log(file.type)
-      return URL.createObjectURL(file)
+      const a = request.headers.get('content-disposition')
+      console.log(a)
+      const filename = request.headers
+        .get('content-disposition')
+        .split('filename=')[1]
+        .replace(/['"]/g, '')
+
+      return {
+        url: URL.createObjectURL(file),
+        name: filename,
+      }
     }
   }
   return newWrappedFetch
@@ -135,11 +144,11 @@ const useApi = () => {
         },
       }
     )
+    console.log(token)
     // temporary catch old style metadata
     if (!token.metadata_keys.includes('')) {
       await getNewMetadata(token)
     } else {
-      console.log(token)
       token.metadata = await wrappedFetch(
         `http://${API_HOST}:${API_PORT}/v2/item/${id}/metadata`,
         {
@@ -151,7 +160,6 @@ const useApi = () => {
           },
         }
       )
-      console.log(token)
     }
 
     return token

--- a/src/utils/vitalamApi.js
+++ b/src/utils/vitalamApi.js
@@ -51,15 +51,16 @@ const useNewFetchWrapper = () => {
       case 'text/plain; charset=utf-8':
         return response.text()
       case 'application/octet-stream': {
-        const file = await response.blob()
-        const filename = response.headers
+        const blob = await response.blob()
+        const url = URL.createObjectURL(blob)
+        const fileName = response.headers
           .get('content-disposition')
           .split('filename=')[1]
           .replace(/['"]/g, '')
 
         return {
-          url: URL.createObjectURL(file),
-          name: filename,
+          url: url,
+          fileName: fileName,
         }
       }
       default:


### PR DESCRIPTION
Adds initial bulk of code for new token formats + updates `ConcludePowderTest` token and any view that uses it. Future PRs to update the other token types will be smaller.

- [x] bump node, API and IPFS versions
- [x] handle user uploaded files as seperate metadata + make available as downloadable attachments
- [x] testReason stays as a text field but is now saved + served as a `.txt` so it's not length limited
- [x] views for when there's no report file or no test reason (see images)
- [x] default role `Admin` -> `Owner`
- [x] add new wrapper for API calls that switches on `content-type` (keeping old one too for now)
- [x] loop through token metadata to GET each `/metadata/{metadata_key}` 
- [x] metadata constants in `/utils`



![image](https://user-images.githubusercontent.com/40722025/151217694-056389d2-9dc6-4cf5-b77c-980a08f61449.png)
![image](https://user-images.githubusercontent.com/40722025/151218510-5231c196-8dfb-48ce-a539-d094fbb6b182.png)

with testReason
![image](https://user-images.githubusercontent.com/40722025/151218697-5f47ddb8-cbb5-4657-85b6-c5b86d2fcdfb.png)
![image](https://user-images.githubusercontent.com/40722025/151218739-02ba51d4-355b-4478-8b58-c87a22c89233.png)
