### PR TITLE
Replace RGB to hex in Inteli Demo

### DIFF
--- a/src/laboratory/components/Navigation.js
+++ b/src/laboratory/components/Navigation.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
     },
   },
   navRequestsAndTestedActive: {
-    color: '#80FFFFFF',
+    color: '#FFFFFF',
     borderBottomColor: 'white',
     borderBottomStyle: 'solid',
     borderBottomWidth: '4px',

--- a/src/laboratory/components/Navigation.js
+++ b/src/laboratory/components/Navigation.js
@@ -5,7 +5,7 @@ import { Container, Grid, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles({
   navRequestsAndTestedBtn: {
-    color: '#80FFFFF',
+    color: '#80FFFFFF',
     textAlign: 'center',
     textDecoration: 'none',
     display: 'block',

--- a/src/laboratory/components/Navigation.js
+++ b/src/laboratory/components/Navigation.js
@@ -5,7 +5,7 @@ import { Container, Grid, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles({
   navRequestsAndTestedBtn: {
-    color: 'rgba(255, 255, 255, 0.5)',
+    color: '#FFFFFF',
     textAlign: 'center',
     textDecoration: 'none',
     display: 'block',
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
     },
   },
   navRequestsAndTestedActive: {
-    color: 'rgba(255, 255, 255)',
+    color: '#FFFFFF',
     borderBottomColor: 'white',
     borderBottomStyle: 'solid',
     borderBottomWidth: '4px',

--- a/src/laboratory/components/Navigation.js
+++ b/src/laboratory/components/Navigation.js
@@ -5,7 +5,7 @@ import { Container, Grid, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles({
   navRequestsAndTestedBtn: {
-    color: '#FFFFFF',
+    color: '#80FFFFF',
     textAlign: 'center',
     textDecoration: 'none',
     display: 'block',
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
     },
   },
   navRequestsAndTestedActive: {
-    color: '#FFFFFF',
+    color: '#80FFFFFF',
     borderBottomColor: 'white',
     borderBottomStyle: 'solid',
     borderBottomWidth: '4px',


### PR DESCRIPTION
**IN-110**
Convert all references to RGB colours to their hex values. 

AC:

INTELI demo uses hex values for colours

************
RGB colours have been replaced with hex.
