### PR TITLE
replaced object assign for order timestamp as does not exist

### DIFF
--- a/src/features/ordersSlice.js
+++ b/src/features/ordersSlice.js
@@ -19,7 +19,7 @@ export const ordersSlice = createSlice({
             Object.assign(order.metadata, action.payload.metadata)
 
             if (action.payload.timestamp) {
-              Object.assign(order.timestamp, action.payload.timestamp)
+              order.timestamp = action.payload.timestamp
             }
           } else {
             console.error(


### PR DESCRIPTION
replaced `Object.assign` on `payload.timestamp` with `order.timestamp = payload.timestamp`