### PR TITLE
Bug/in 178

### DIFF
--- a/helm/inteli-demo/Chart.yaml
+++ b/helm/inteli-demo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-demo
-appVersion: '2.1.1'
+appVersion: '2.1.2'
 description: A Helm chart for inteli-demo
-version: '2.1.1'
+version: '2.1.2'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-demo/values.yaml
+++ b/helm/inteli-demo/values.yaml
@@ -25,4 +25,4 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/inteli-demo
   pullPolicy: IfNotPresent
-  tag: 'v2.1.1'
+  tag: 'v2.1.2'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inteli-demo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inteli-demo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Demo for INTELI",
   "author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "license": "Apache-2.0",

--- a/src/customer/components/CustomerPartItems.js
+++ b/src/customer/components/CustomerPartItems.js
@@ -3,21 +3,11 @@ import CustomerPartItem from './CustomerPartItem'
 import { Grid } from '@material-ui/core'
 
 const CustomerPartItems = ({ items }) => {
-  return (
-    <Grid
-      container
-      item
-      direction="row"
-      spacing={2}
-      justifyContent="flex-start"
-    >
-      {items.map((item) => (
-        <Grid item key={item.partId}>
-          <CustomerPartItem {...item} />
-        </Grid>
-      ))}
+  return items.map((item) => (
+    <Grid item key={item.partId}>
+      <CustomerPartItem {...item} />
     </Grid>
-  )
+  ))
 }
 
 export default CustomerPartItems

--- a/src/customer/components/CustomerParts.js
+++ b/src/customer/components/CustomerParts.js
@@ -1,24 +1,13 @@
 import React, { useState } from 'react'
-import { Box, Grid, Typography } from '@material-ui/core'
-import makeStyles from '@material-ui/core/styles/makeStyles'
+import { Grid, Typography } from '@material-ui/core'
 import { useSelector } from 'react-redux'
 
 import SearchField from './SearchField'
 import CustomerPartItems from './CustomerPartItems'
-
-const useStyles = makeStyles({
-  searchFieldContainer: {
-    marginBottom: 8,
-  },
-  searchResultsTotal: {
-    marginTop: 16,
-  },
-})
+import Spacer from '../../shared/Spacer'
 
 const CustomerParts = () => {
   const customerParts = useSelector((state) => state.customerParts)
-  const classes = useStyles()
-
   const [filteredParts, setFilteredParts] = useState(customerParts)
   const [searchReady, setSearchReady] = useState(false)
   const [search, setSearch] = useState('')
@@ -59,25 +48,24 @@ const CustomerParts = () => {
   }
 
   return (
-    <Box>
-      <Grid
-        container
-        direction="row"
-        className={classes.searchFieldContainer}
-        justifyContent="flex-start"
-      >
-        <Grid item xs={11}>
+    <Grid container direction="column" justiifyContent="center">
+      <Grid container direction="row" justifyContent="center">
+        <Spacer height={6} />
+        <Grid item xs={10}>
           <SearchField handleChange={searchBy} />
         </Grid>
-        <Grid item xs={1} className={classes.searchResultsTotal}>
+        <Grid item>
           <Typography color="textSecondary">
             {customerParts && customerParts.length ? filteredParts.length : 0}{' '}
             results
           </Typography>
         </Grid>
+        <Spacer />
+        <Grid container item xs={10} spacing={2}>
+          {getParts()}
+        </Grid>
       </Grid>
-      {getParts()}
-    </Box>
+    </Grid>
   )
 }
 

--- a/src/customer/components/Header.js
+++ b/src/customer/components/Header.js
@@ -7,7 +7,6 @@ const useStyles = makeStyles({
   root: {
     minHeight: '60px',
     background: '#ff0033',
-    
   },
 })
 

--- a/src/customer/components/Header.js
+++ b/src/customer/components/Header.js
@@ -1,21 +1,26 @@
 import React from 'react'
 import Navigation from './Navigation'
 
-import { AppBar, makeStyles } from '@material-ui/core'
+import { AppBar, makeStyles, Grid } from '@material-ui/core'
 
 const useStyles = makeStyles({
   root: {
-    height: '60px',
+    minHeight: '60px',
     background: '#ff0033',
+    
   },
 })
 
 const Header = () => {
   const classes = useStyles()
   return (
-    <AppBar position="sticky" className={classes.root}>
-      <Navigation />
-    </AppBar>
+    <Grid container>
+      <Grid item xs={12}>
+        <AppBar position="sticky" className={classes.root}>
+          <Navigation />
+        </AppBar>
+      </Grid>
+    </Grid>
   )
 }
 

--- a/src/customer/components/MyOrders.js
+++ b/src/customer/components/MyOrders.js
@@ -1,65 +1,10 @@
 import React, { useEffect } from 'react'
 import { Grid } from '@material-ui/core'
-import makeStyles from '@material-ui/core/styles/makeStyles'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import SummaryRow from './SummaryRow'
 import OrderSummary from './OrderSummary'
-
-const useStyles = makeStyles((theme) => ({
-  backButton: {
-    textDecoration: 'none',
-    color: theme.palette.primary.main,
-  },
-  order: {
-    width: '100%',
-    border: 'solid #ccc 1px',
-    paddingTop: '20px',
-    marginBottom: '8px',
-  },
-  detailText: {
-    display: 'inline',
-  },
-  name: {
-    marginBottom: '20px',
-  },
-  mainPadding: {
-    paddingTop: '130px',
-  },
-  leftColumn: {
-    width: '390px',
-  },
-  rightColumn: {
-    width: '1146px',
-    borderRadius: '8px',
-  },
-  maherStyle: {
-    backgroundColor: '#0C74BB',
-    color: '#ffff',
-    padding: '5px',
-    border: ' 1px solid 0C74BB',
-    borderRadius: '3px',
-    marginRight: '20px',
-  },
-  listPadding: {
-    marginBottom: '10px',
-  },
-  listItemMargin: {
-    marginBottom: '60px',
-  },
-  datePadding: {
-    paddingLeft: '80px',
-  },
-  containerWidth: {
-    width: '1546px',
-  },
-  active: {
-    background: 'green',
-  },
-  notActive: {
-    background: 'red',
-  },
-}))
+import Spacer from '../../shared/Spacer'
 
 const getSelectedOrder = (orders, paramsId) => {
   if (orders.length > 0) {
@@ -78,8 +23,6 @@ const MyOrders = () => {
   const customerOrders = useSelector((state) => state.customerOrders)
   const selectedOrder = getSelectedOrder(customerOrders, params.orderId)
 
-  const classes = useStyles()
-
   useEffect(() => {
     if (selectedOrder) {
       navigate({
@@ -89,8 +32,9 @@ const MyOrders = () => {
   }, [navigate, selectedOrder])
 
   return (
-    <Grid container className={classes.containerWidth}>
-      <Grid item className={classes.leftColumn}>
+    <Grid container>
+      <Spacer height={5} />
+      <Grid item sm={12} md="auto">
         {[...customerOrders].reverse().map((order) => (
           <SummaryRow
             key={order.id}
@@ -99,7 +43,7 @@ const MyOrders = () => {
           />
         ))}
       </Grid>
-      <Grid item className={classes.rightColumn}>
+      <Grid item sm={12} md="auto">
         {selectedOrder && <OrderSummary order={selectedOrder} />}
       </Grid>
     </Grid>

--- a/src/customer/components/Navigation.js
+++ b/src/customer/components/Navigation.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 import makeStyles from '@material-ui/core/styles/makeStyles'
-import { Toolbar, Typography, Box } from '@material-ui/core'
+import { Toolbar, Typography, Box, Grid } from '@material-ui/core'
 
 import NetworkStatusIndicator from './NetworkStatusIndicator'
 import images from '../../images'
@@ -10,11 +10,10 @@ import { useAuth0 } from '@auth0/auth0-react'
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    marginLeft: '100px',
-    marginRight: '100px',
+    marginLeft: '10px',
+    marginRight: '10px',
   },
   logo: {
-    marginRight: 'auto',
     height: '50px',
     display: 'grid',
     gridTemplateColumns: 'auto auto',
@@ -80,45 +79,61 @@ const Navigation = () => {
 
   return (
     <Toolbar className={classes.root}>
-      <div className={classes.logo}>
-        <img src={images.logoCust}></img>
-      </div>
-      <NavLink
-        to="/app/customer-parts"
-        className={`${classes.navButton} ${classes.navHover}`}
-        activeclassname={classes.navActive}
-      >
-        <Typography variant="subtitle2">Part inventory</Typography>
-      </NavLink>
-      <NavLink
-        to="/app/my-orders"
-        className={`${classes.navButton} ${classes.navHover}`}
-        activeclassname={classes.navActive}
-      >
-        <Typography variant="subtitle2">My orders</Typography>
-      </NavLink>
-      <NavLink
-        className={`${classes.accountNameWrapper} ${classes.navHover}`}
-        to="#"
-      >
-        <Typography variant="subtitle2">{name}</Typography>
-        <Typography className={classes.avatar}>
-          {name.substring(0, 1)}
-        </Typography>
-      </NavLink>
-      <Box className={classes.navButton}>
-        <NetworkStatusIndicator />
-      </Box>
-      {isAuthenticated && (
-        <Box
-          className={`${classes.navButtonWrapping} ${classes.logout} ${classes.navButton} ${classes.navHover}`}
-          onClick={() =>
-            logout({ returnTo: `${getCurrentBaseUrl()}/app/customer-parts` })
-          }
-        >
-          <Typography>Log Out</Typography>
-        </Box>
-      )}
+      <Grid container alignItems="center" justifyContent="center">
+        <Grid item>
+          <div className={classes.logo}>
+            <img src={images.logoCust}></img>
+          </div>
+        </Grid>
+        <Grid item md={2}>
+          <NavLink
+            to="/app/customer-parts"
+            className={`${classes.navButton} ${classes.navHover}`}
+            activeclassname={classes.navActive}
+          >
+            <Typography variant="subtitle2">Part inventory</Typography>
+          </NavLink>
+        </Grid>
+        <Grid item>
+          <NavLink
+            to="/app/my-orders"
+            className={`${classes.navButton} ${classes.navHover}`}
+            activeclassname={classes.navActive}
+          >
+            <Typography variant="subtitle2">My orders</Typography>
+          </NavLink>
+        </Grid>
+        <Grid item>
+          <NavLink
+            className={`${classes.accountNameWrapper} ${classes.navHover}`}
+            to="#"
+          >
+            <Typography variant="subtitle2">{name}</Typography>
+            <Typography className={classes.avatar}>
+              {name.substring(0, 1)}
+            </Typography>
+          </NavLink>
+        </Grid>
+        <Grid item xs={1}>
+          <Box className={classes.navButton}>
+            <NetworkStatusIndicator />
+          </Box>
+        </Grid>
+        <Grid>
+          {isAuthenticated && (
+            <Box
+              className={`${classes.navButtonWrapping} ${classes.logout} ${classes.navButton} ${classes.navHover}`}
+              onClick={() =>
+                logout({
+                  returnTo: `${getCurrentBaseUrl()}/app/customer-parts`,
+                })
+              }
+            >
+              <Typography>Log Out</Typography>
+            </Box>
+          )}
+        </Grid>
+      </Grid>
     </Toolbar>
   )
 }

--- a/src/customer/components/SearchField.js
+++ b/src/customer/components/SearchField.js
@@ -1,25 +1,15 @@
 import React from 'react'
-import styled from 'styled-components'
 import TextField from '@material-ui/core/TextField'
 
 const SearchField = ({ handleChange }) => {
   return (
-    <Wrapper>
-      <TextField
-        id="standard-full-width"
-        placeholder="Search by name, partId, material or alloy..."
-        fullWidth
-        onChange={handleChange}
-        name="customerSearchPart"
-      />
-    </Wrapper>
+    <TextField
+      placeholder="Search by name, partId, material or alloy..."
+      onChange={handleChange}
+      fullWidth
+      name="customerSearchPart"
+    />
   )
 }
-
-const Wrapper = styled.div`
-  display: flex;
-  padding: 8px 0px;
-  width: 625px;
-`
 
 export default SearchField

--- a/src/customer/components/SummaryRow.js
+++ b/src/customer/components/SummaryRow.js
@@ -23,19 +23,11 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: '20px',
   },
   listItemMargin: {
-    marginBottom: '60px',
+    marginBottom: '10px',
   },
   datePadding: {
     paddingLeft: '103px',
     paddingTop: '5px',
-  },
-  root: {
-    padding: 8,
-    width: '100%',
-    height: '100px',
-    marginBottom: '25px',
-    borderRadius: '8px',
-    textDecoration: 'none',
   },
   isNotActive: {
     background: '#f8f8f8',
@@ -71,9 +63,7 @@ const SummaryRow = ({ order, activeItem }) => {
     <Paper
       id={orderId}
       elevation={0}
-      className={`${classes.root} ${
-        activeItem ? classes.isActive : classes.isNotActive
-      }`}
+      className={`${activeItem ? classes.isActive : classes.isNotActive}`}
     >
       <CardActionArea
         onClick={() => {}}

--- a/src/customer/index.js
+++ b/src/customer/index.js
@@ -1,7 +1,7 @@
-import React from 'react'
 import 'reset-css'
+import React from 'react'
 import { createTheme, ThemeProvider } from '@material-ui/core/styles'
-import { makeStyles, Container } from '@material-ui/core'
+import { Container } from '@material-ui/core'
 import { BrowserRouter } from 'react-router-dom'
 
 import Header from './components/Header'
@@ -19,20 +19,12 @@ const theme = createTheme({
   },
 })
 
-const useStyles = makeStyles({
-  content: {
-    margin: '130px 187px 87px 187px',
-  },
-})
-
 const CustomerApp = () => {
-  const classes = useStyles()
-
   return (
     <BrowserRouter>
       <ThemeProvider theme={theme}>
         <Header />
-        <Container className={classes.content}>
+        <Container>
           <Router />
         </Container>
       </ThemeProvider>

--- a/src/shared/BlockchainWatcher.js
+++ b/src/shared/BlockchainWatcher.js
@@ -50,7 +50,7 @@ const BlockchainWatcher = ({ children }) => {
         )
       }
       if (timer !== null) {
-        timer = setTimeout(timerFn, 1000)
+        timer = setTimeout(timerFn, 3000)
       }
     }
     timer = setTimeout(timerFn, 0)

--- a/src/shared/Spacer.js
+++ b/src/shared/Spacer.js
@@ -1,0 +1,13 @@
+import { Grid } from '@material-ui/core'
+import React from 'react'
+
+/*
+  a simple spacer component that takes one prop `height` which will be multiplied by 10px
+*/
+const Spacer = ({ height = 2 }) => (
+  <Grid item xs={12}>
+    <div style={{ height: `${height * 10}px` }}></div>
+  </Grid>
+)
+
+export default Spacer


### PR DESCRIPTION
### What

Not much going on here, fixing some of front-end madness. Looks like we are not using Material UI Grid and otheer elements correctly. A lot of hard coded width and heigh values including margins have been discovered and some removed.

#### Changes
- new component: `<Spacer />` that take one prop `height` and multiplies by 10 and renders in pixels e.g. `height={1}` = `10px`
- removed a lot of hard coded css e.g. width, margins and etc

### Screenshots

Please ignore empty images, was just being lazy to strart a substrate node

<img width="1680" alt="Screenshot 2022-04-01 at 13 26 18" src="https://user-images.githubusercontent.com/11794402/161263013-03aa24de-915a-45db-9478-e6812a274a30.png">
<img width="1178" alt="Screenshot 2022-04-01 at 13 24 32" src="https://user-images.githubusercontent.com/11794402/161263015-bc28d1d2-fff8-4dbf-b4e5-bee8e931df2f.png">
<img width="553" alt="Screenshot 2022-04-01 at 13 24 17" src="https://user-images.githubusercontent.com/11794402/161262699-587d442c-239d-48e6-aebc-0deb2dda771a.png">
<img width="863" alt="Screenshot 2022-04-01 at 13 24 11" src="https://user-images.githubusercontent.com/11794402/161262702-ccde3bfa-94ab-4be9-9cff-2db5aa2bac56.png">
<img width="1369" alt="Screenshot 2022-04-01 at 13 24 05" src="https://user-images.githubusercontent.com/11794402/161262705-81dc414e-0067-4fa5-9bbd-dfa65d29c3f0.png">
<img width="770" alt="Screenshot 2022-04-01 at 13 24 26" src="https://user-images.githubusercontent.com/11794402/161262695-a9ee9284-97d6-4b3e-a06d-0a00d0b93880.png">

