### PR TITLE
Feature/in 196

### DIFF
--- a/helm/inteli-demo/Chart.yaml
+++ b/helm/inteli-demo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: inteli-demo
-appVersion: '2.2.0'
+appVersion: '2.2.1'
 description: A Helm chart for inteli-demo
-version: '2.2.0'
+version: '2.2.1'
 type: application
 maintainers:
   - name: digicatapult

--- a/helm/inteli-demo/values.yaml
+++ b/helm/inteli-demo/values.yaml
@@ -25,4 +25,4 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/inteli-demo
   pullPolicy: IfNotPresent
-  tag: 'v2.2.0'
+  tag: 'v2.2.1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inteli-demo",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inteli-demo",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Demo for INTELI",
   "author": "Digital Catapult (https://www.digicatapult.org.uk/)",
   "license": "Apache-2.0",

--- a/src/customer/components/MyOrders.js
+++ b/src/customer/components/MyOrders.js
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react'
 import { Grid } from '@material-ui/core'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useSelector } from 'react-redux'
+import moment from 'moment'
+
 import SummaryRow from './SummaryRow'
 import OrderSummary from './OrderSummary'
 import Spacer from '../../shared/Spacer'
@@ -15,6 +17,18 @@ const getSelectedOrder = (orders, paramsId) => {
     return null
   }
 }
+
+// A temporary solution for generating a seeded pseudo random
+// with min and max values, max = max - min (which is not handled)
+const getForecastDate = (timestamp, max = 20, min = 3) => {
+  let unix = moment(timestamp).unix()
+  const n = Math.sin(unix++) * 10000
+
+  return moment(timestamp)
+    .add(parseInt((n - Math.floor(n)) * max) + min, 'days')
+    .format('DD MMM YYYY')
+}
+
 const MyOrders = () => {
   const params = useParams()
   const navigate = useNavigate()
@@ -35,13 +49,19 @@ const MyOrders = () => {
     <Grid container>
       <Spacer height={5} />
       <Grid item sm={12} md={3}>
-        {[...customerOrders].reverse().map((order) => (
-          <SummaryRow
-            key={order.id}
-            order={order}
-            activeItem={selectedOrder && selectedOrder.id === order.id}
-          />
-        ))}
+        {[...customerOrders].reverse().map((order) => {
+          const forecastDate = getForecastDate(order.timestamp)
+          return (
+            <SummaryRow
+              key={order.id}
+              order={{
+                forecastDate,
+                ...order,
+              }}
+              activeItem={selectedOrder && selectedOrder.id === order.id}
+            />
+          )
+        })}
       </Grid>
       <Grid item sm={12} md={9}>
         {selectedOrder && <OrderSummary order={selectedOrder} />}

--- a/src/customer/components/MyOrders.js
+++ b/src/customer/components/MyOrders.js
@@ -20,7 +20,7 @@ const getSelectedOrder = (orders, paramsId) => {
 
 // A temporary solution for generating a seeded pseudo random
 // with min and max values, max = max - min (which is not handled)
-const getForecastDate = (timestamp, max = 20, min = 3) => {
+const getForecastDate = (timestamp, max = 12, min = 3) => {
   let unix = moment(timestamp).unix()
   const n = Math.sin(unix++) * 10000
 

--- a/src/customer/components/MyOrders.js
+++ b/src/customer/components/MyOrders.js
@@ -34,7 +34,7 @@ const MyOrders = () => {
   return (
     <Grid container>
       <Spacer height={5} />
-      <Grid item sm={12} md="auto">
+      <Grid item sm={12} md={3}>
         {[...customerOrders].reverse().map((order) => (
           <SummaryRow
             key={order.id}
@@ -43,7 +43,7 @@ const MyOrders = () => {
           />
         ))}
       </Grid>
-      <Grid item sm={12} md="auto">
+      <Grid item sm={12} md={9}>
         {selectedOrder && <OrderSummary order={selectedOrder} />}
       </Grid>
     </Grid>

--- a/src/customer/components/SummaryRow.js
+++ b/src/customer/components/SummaryRow.js
@@ -59,7 +59,7 @@ const SummaryRow = ({ order, activeItem }) => {
     forecastDate,
   } = order
   const tokenTimestampFormattedDate = moment(timestamp).format('DD MMM YYYY')
-  const isForecastLate = moment(forecastDate).diff(timestamp, 'days') > 5
+  const isForecastLate = moment(forecastDate).diff(timestamp, 'days') > 7
 
   return (
     <Paper

--- a/src/customer/components/SummaryRow.js
+++ b/src/customer/components/SummaryRow.js
@@ -9,6 +9,7 @@ import {
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import { Link as RouterLink } from 'react-router-dom'
 import moment from 'moment'
+import Spacer from '../../shared/Spacer'
 
 const useStyles = makeStyles((theme) => ({
   maherStyle: {
@@ -50,14 +51,15 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const SummaryRow = ({ order, activeItem }) => {
+  const classes = useStyles()
   const {
     id: orderId,
     metadata: { name, orderImage, quantity },
     timestamp,
+    forecastDate,
   } = order
-
-  const classes = useStyles()
   const tokenTimestampFormattedDate = moment(timestamp).format('DD MMM YYYY')
+  const isForecastLate = moment(forecastDate).diff(timestamp, 'days') > 5
 
   return (
     <Paper
@@ -104,13 +106,39 @@ const SummaryRow = ({ order, activeItem }) => {
             >
               Qnt: {quantity}
             </Typography>
-            <Typography
-              variant="subtitle2"
-              component="h6"
-              className={`${classes.datePadding} ${classes.threeFiftyFont} ${classes.dateColour} `}
-            >
-              {tokenTimestampFormattedDate}
-            </Typography>
+            <Spacer height={1} />
+            <Grid container direction="row" alignItems="center">
+              <Grid item xs={6}>
+                <Typography variant="subtitle2" component="h6">
+                  Order Date:
+                </Typography>
+              </Grid>
+              <Grid item xs={6}>
+                <Typography
+                  style={{ color: '#a1a1a1' }}
+                  variant="subtitle2"
+                  component="h6"
+                >
+                  {tokenTimestampFormattedDate}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid container direction="row" alignItems="center">
+              <Grid item xs={6}>
+                <Typography variant="subtitle2" component="h6">
+                  Forecast:
+                </Typography>
+              </Grid>
+              <Grid item xs={6}>
+                <Typography
+                  style={{ color: isForecastLate ? 'red' : '#a1a1a1' }}
+                  variant="subtitle2"
+                  component="h6"
+                >
+                  {forecastDate}
+                </Typography>
+              </Grid>
+            </Grid>
           </Grid>
         </Grid>
       </CardActionArea>


### PR DESCRIPTION
### What

A placeholder with a pseudo random number raging from 3-20 for forecasting order fulfilment date. Order will always have the same random number as we are seeding based on order timestamp. Please treat this as a placeholder for later implementation

#### Change
- new helper function for generating a seeded pseudo random with min/max
- tidy up some components (summary card, my order)

#### Screengrabs
<img width="317" alt="Screenshot 2022-04-06 at 16 19 59" src="https://user-images.githubusercontent.com/11794402/162010164-7286bc15-fa08-491c-876e-cc3dc73eb672.png">
<img width="295" alt="Screenshot 2022-04-06 at 16 19 47" src="https://user-images.githubusercontent.com/11794402/162010174-8d5e8cc1-cb48-4e0c-a565-aa11a022420f.png">
<img width="273" alt="Screenshot 2022-04-06 at 16 19 42" src="https://user-images.githubusercontent.com/11794402/162010177-eec15f34-09e4-423c-b515-1c3d27cdf89c.png">

